### PR TITLE
Add abstract + intro for draft patterns protocol

### DIFF
--- a/draft-ietf-patterns-protocol.md
+++ b/draft-ietf-patterns-protocol.md
@@ -38,6 +38,10 @@ informative:
 
 This document describes patterns as supported within a matching libraries with the goal standardizing querying fields within data objects through an easy to express query language across many different libraries.
 
+# About This Document
+
+This is a work in progress. It is not ready for consumption or reference. Prior art can be found at https://github.com/timbray/quamina/blob/main/PATTERNS.md 
+
 --- middle
 
 Introduction        {#intro}

--- a/draft-ietf-patterns-protocol.md
+++ b/draft-ietf-patterns-protocol.md
@@ -36,7 +36,8 @@ informative:
 
 --- abstract
 
-This RFC describes patterns as supported within a matching library.
+This document describes patterns as supported within a matching libraries with the goal standardizing querying fields within data objects through an easy to express query language across many different libraries.
+
 --- middle
 
 # Introduction

--- a/draft-ietf-patterns-protocol.md
+++ b/draft-ietf-patterns-protocol.md
@@ -40,7 +40,8 @@ This document describes patterns as supported within a matching libraries with t
 
 --- middle
 
-# Introduction
+Introduction        {#intro}
+============
 
 The patterns provides a way to query JSON documents as described in [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259.html). The patterns are defined using a simple JSON syntax to make it easy to read, write, and manipulate such that they can be prefered over ad-hoc parsing and manipulation of code for further operations such as filtering, selection, and transfomring of data based on specific patterns. Additionally, This document describes the syntax and semantics of the patterns, along with examples of how they can be used in practice. Finally, the document provides guidelines for creating new patterns that conform to the existing syntax and semantics. Overall, this RFC aims to guide the functionality of the JSON-based library by providing a powerful pattern matching capability that enables users to work with JSON data in a more flexible and intuitive way.
 
@@ -65,4 +66,4 @@ This document has no IANA actions.
 # Acknowledgments
 {:numbered="false"}
 
-TODO acknowledge.
+TODO acknowledge [Quamina](https://github.com/timbray/quamina) and [Ruler](https://github.com/aws/event-ruler)

--- a/draft-ietf-patterns-protocol.md
+++ b/draft-ietf-patterns-protocol.md
@@ -26,7 +26,7 @@ venue:
 author:
  -
     fullname: Rishi Baldawa
-    organization: Your Organization Here
+    organization: TBC
     email: "baldawar@amazon.com"
 
 normative:
@@ -36,14 +36,12 @@ informative:
 
 --- abstract
 
-TODO Abstract
-
-
+This RFC describes patterns as supported within a matching library. 
 --- middle
 
 # Introduction
 
-TODO Introduction
+The patterns provides a way to query JSON documents as described in [RFC 8259](https://www.rfc-editor.org/rfc/rfc8259.html). The patterns are defined using a simple JSON syntax to make it easy to read, write, and manipulate such that they can be prefered over ad-hoc parsing and manipulation of code for further operations such as filtering, selection, and transfomring of data based on specific patterns. Additionally, This document describes the syntax and semantics of the patterns, along with examples of how they can be used in practice. Finally, the document provides guidelines for creating new patterns that conform to the existing syntax and semantics. Overall, this RFC aims to guide the functionality of the JSON-based library by providing a powerful pattern matching capability that enables users to work with JSON data in a more flexible and intuitive way.
 
 
 # Conventions and Definitions

--- a/draft-ietf-patterns-protocol.md
+++ b/draft-ietf-patterns-protocol.md
@@ -36,7 +36,7 @@ informative:
 
 --- abstract
 
-This RFC describes patterns as supported within a matching library. 
+This RFC describes patterns as supported within a matching library.
 --- middle
 
 # Introduction

--- a/draft-ietf-patterns-protocol.md
+++ b/draft-ietf-patterns-protocol.md
@@ -40,7 +40,7 @@ This document describes patterns as supported within a matching libraries with t
 
 # About This Document
 
-This is a work in progress. It is not ready for consumption or reference. Prior art can be found at https://github.com/timbray/quamina/blob/main/PATTERNS.md 
+This is a work in progress. It is not ready for consumption or reference. Prior art can be found at https://github.com/timbray/quamina/blob/main/PATTERNS.md.
 
 --- middle
 
@@ -70,4 +70,4 @@ This document has no IANA actions.
 # Acknowledgments
 {:numbered="false"}
 
-TODO acknowledge [Quamina](https://github.com/timbray/quamina) and [Ruler](https://github.com/aws/event-ruler)
+TODO acknowledge [Quamina](https://github.com/timbray/quamina) and [Ruler](https://github.com/aws/event-ruler).


### PR DESCRIPTION
Following https://authors.ietf.org/en/required-content as guidance. Went the wrong way earlier this month, so start small this time and submitting PRs in pieces.